### PR TITLE
adapt the lezer grammar and codemirror autocompletion with duration and number that are equivalent

### DIFF
--- a/web/ui/module/codemirror-promql/src/complete/hybrid.test.ts
+++ b/web/ui/module/codemirror-promql/src/complete/hybrid.test.ts
@@ -431,13 +431,13 @@ describe('analyzeCompletion test', () => {
       title: 'autocomplete duration with offset',
       expr: 'http_requests_total offset 5',
       pos: 28,
-      expectedContext: [{ kind: ContextKind.Duration }],
+      expectedContext: [{ kind: ContextKind.Duration }, { kind: ContextKind.Number }],
     },
     {
       title: 'autocomplete duration with offset',
       expr: 'sum(http_requests_total{method="GET"} offset 4)',
       pos: 46,
-      expectedContext: [{ kind: ContextKind.Duration }],
+      expectedContext: [{ kind: ContextKind.Duration }, { kind: ContextKind.Number }],
     },
     {
       title: 'autocomplete offset or binOp',
@@ -485,49 +485,49 @@ describe('analyzeCompletion test', () => {
       title: 'autocomplete duration for a matrixSelector',
       expr: 'go[5]',
       pos: 4,
-      expectedContext: [{ kind: ContextKind.Duration }],
+      expectedContext: [{ kind: ContextKind.Duration }, { kind: ContextKind.Number }],
     },
     {
       title: 'autocomplete duration for a matrixSelector 2',
       expr: 'go[5d1]',
       pos: 6,
-      expectedContext: [{ kind: ContextKind.Duration }],
+      expectedContext: [{ kind: ContextKind.Duration }, { kind: ContextKind.Number }],
     },
     {
       title: 'autocomplete duration for a matrixSelector 3',
       expr: 'rate(my_metric{l1="l2"}[25])',
       pos: 26,
-      expectedContext: [{ kind: ContextKind.Duration }],
+      expectedContext: [{ kind: ContextKind.Duration }, { kind: ContextKind.Number }],
     },
     {
       title: 'autocomplete duration for a matrixSelector 4',
       expr: 'rate(my_metric{l1="l2"}[25d5])',
       pos: 28,
-      expectedContext: [{ kind: ContextKind.Duration }],
+      expectedContext: [{ kind: ContextKind.Duration }, { kind: ContextKind.Number }],
     },
     {
       title: 'autocomplete duration for a subQuery',
       expr: 'go[5d:5]',
       pos: 7,
-      expectedContext: [{ kind: ContextKind.Duration }],
+      expectedContext: [{ kind: ContextKind.Duration }, { kind: ContextKind.Number }],
     },
     {
       title: 'autocomplete duration for a subQuery 2',
       expr: 'go[5d:5d4]',
       pos: 9,
-      expectedContext: [{ kind: ContextKind.Duration }],
+      expectedContext: [{ kind: ContextKind.Duration }, { kind: ContextKind.Number }],
     },
     {
       title: 'autocomplete duration for a subQuery 3',
       expr: 'rate(my_metric{l1="l2"}[25d:6])',
       pos: 29,
-      expectedContext: [{ kind: ContextKind.Duration }],
+      expectedContext: [{ kind: ContextKind.Duration }, { kind: ContextKind.Number }],
     },
     {
       title: 'autocomplete duration for a subQuery 4',
       expr: 'rate(my_metric{l1="l2"}[25d:6d5])',
       pos: 31,
-      expectedContext: [{ kind: ContextKind.Duration }],
+      expectedContext: [{ kind: ContextKind.Duration }, { kind: ContextKind.Number }],
     },
     {
       title: 'autocomplete at modifiers',
@@ -805,6 +805,17 @@ describe('autocomplete promQL test', () => {
       },
     },
     {
+      title: 'offline function/aggregation autocompletion in aggregation 5',
+      expr: 'sum by (instance, job) ( sum_ove(scrape_series_added))',
+      pos: 32,
+      expectedResult: {
+        options: ([] as Completion[]).concat(functionIdentifierTerms, aggregateOpTerms, snippets),
+        from: 25,
+        to: 32,
+        validFor: /^[a-zA-Z0-9_:]+$/,
+      },
+    },
+    {
       title: 'autocomplete binOp modifier/metric/number',
       expr: 'metric_name / ignor',
       pos: 19,
@@ -1007,7 +1018,7 @@ describe('autocomplete promQL test', () => {
       expr: 'http_requests_total offset 5',
       pos: 28,
       expectedResult: {
-        options: durationTerms,
+        options: ([] as Completion[]).concat(durationTerms, numberTerms),
         from: 28,
         to: 28,
         validFor: undefined,
@@ -1018,7 +1029,7 @@ describe('autocomplete promQL test', () => {
       expr: 'sum(http_requests_total{method="GET"} offset 4)',
       pos: 46,
       expectedResult: {
-        options: durationTerms,
+        options: ([] as Completion[]).concat(durationTerms, numberTerms),
         from: 46,
         to: 46,
         validFor: undefined,
@@ -1106,7 +1117,7 @@ describe('autocomplete promQL test', () => {
       expr: 'go[5]',
       pos: 4,
       expectedResult: {
-        options: durationTerms,
+        options: ([] as Completion[]).concat(durationTerms, numberTerms),
         from: 4,
         to: 4,
         validFor: undefined,
@@ -1117,7 +1128,7 @@ describe('autocomplete promQL test', () => {
       expr: 'go[5d1]',
       pos: 6,
       expectedResult: {
-        options: durationTerms,
+        options: ([] as Completion[]).concat(durationTerms, numberTerms),
         from: 6,
         to: 6,
         validFor: undefined,
@@ -1128,7 +1139,7 @@ describe('autocomplete promQL test', () => {
       expr: 'rate(my_metric{l1="l2"}[25])',
       pos: 26,
       expectedResult: {
-        options: durationTerms,
+        options: ([] as Completion[]).concat(durationTerms, numberTerms),
         from: 26,
         to: 26,
         validFor: undefined,
@@ -1139,7 +1150,7 @@ describe('autocomplete promQL test', () => {
       expr: 'rate(my_metric{l1="l2"}[25d5])',
       pos: 28,
       expectedResult: {
-        options: durationTerms,
+        options: ([] as Completion[]).concat(durationTerms, numberTerms),
         from: 28,
         to: 28,
         validFor: undefined,
@@ -1150,7 +1161,7 @@ describe('autocomplete promQL test', () => {
       expr: 'go[5d:5]',
       pos: 7,
       expectedResult: {
-        options: durationTerms,
+        options: ([] as Completion[]).concat(durationTerms, numberTerms),
         from: 7,
         to: 7,
         validFor: undefined,
@@ -1161,7 +1172,7 @@ describe('autocomplete promQL test', () => {
       expr: 'go[5d:5d4]',
       pos: 9,
       expectedResult: {
-        options: durationTerms,
+        options: ([] as Completion[]).concat(durationTerms, numberTerms),
         from: 9,
         to: 9,
         validFor: undefined,
@@ -1172,7 +1183,7 @@ describe('autocomplete promQL test', () => {
       expr: 'rate(my_metric{l1="l2"}[25d:6])',
       pos: 29,
       expectedResult: {
-        options: durationTerms,
+        options: ([] as Completion[]).concat(durationTerms, numberTerms),
         from: 29,
         to: 29,
         validFor: undefined,
@@ -1183,7 +1194,7 @@ describe('autocomplete promQL test', () => {
       expr: 'rate(my_metric{l1="l2"}[25d:6d5])',
       pos: 31,
       expectedResult: {
-        options: durationTerms,
+        options: ([] as Completion[]).concat(durationTerms, numberTerms),
         from: 31,
         to: 31,
         validFor: undefined,

--- a/web/ui/module/codemirror-promql/src/complete/hybrid.ts
+++ b/web/ui/module/codemirror-promql/src/complete/hybrid.ts
@@ -21,7 +21,6 @@ import {
   BinaryExpr,
   BoolModifier,
   Div,
-  Duration,
   Eql,
   EqlRegex,
   EqlSingle,
@@ -41,7 +40,6 @@ import {
   Mul,
   Neq,
   NeqRegex,
-  NumberLiteral,
   OffsetExpr,
   Or,
   Pow,
@@ -52,6 +50,7 @@ import {
   SubqueryExpr,
   Unless,
   VectorSelector,
+  NumberDurationLiteral,
 } from '@prometheus-io/lezer-promql';
 import { Completion, CompletionContext, CompletionResult } from '@codemirror/autocomplete';
 import { EditorState } from '@codemirror/state';
@@ -186,11 +185,11 @@ export function computeStartCompletePosition(node: SyntaxNode, pos: number): num
     start++;
   } else if (
     node.type.id === OffsetExpr ||
-    (node.type.id === NumberLiteral && node.parent?.type.id === 0 && node.parent.parent?.type.id === SubqueryExpr) ||
+    node.type.id === NumberDurationLiteral ||
     (node.type.id === 0 &&
       (node.parent?.type.id === OffsetExpr ||
         node.parent?.type.id === MatrixSelector ||
-        (node.parent?.type.id === SubqueryExpr && containsAtLeastOneChild(node.parent, Duration))))
+        (node.parent?.type.id === SubqueryExpr && containsAtLeastOneChild(node.parent, NumberDurationLiteral))))
   ) {
     start = pos;
   }
@@ -222,14 +221,14 @@ export function analyzeCompletion(state: EditorState, node: SyntaxNode): Context
         // we are likely in the given situation:
         // `metric_name{}[5]`
         // We can also just autocomplete a duration
-        result.push({ kind: ContextKind.Duration });
+        result.push({ kind: ContextKind.Duration }, { kind: ContextKind.Number });
         break;
       }
-      if (node.parent?.type.id === SubqueryExpr && containsAtLeastOneChild(node.parent, Duration)) {
+      if (node.parent?.type.id === SubqueryExpr && containsAtLeastOneChild(node.parent, NumberDurationLiteral)) {
         // we are likely in the given situation:
         //    `rate(foo[5d:5])`
         // so we should autocomplete a duration
-        result.push({ kind: ContextKind.Duration });
+        result.push({ kind: ContextKind.Duration }, { kind: ContextKind.Number });
         break;
       }
       // when we are in the situation 'metric_name !', we have the following tree
@@ -295,8 +294,8 @@ export function analyzeCompletion(state: EditorState, node: SyntaxNode): Context
           break;
         }
       }
-      // As the leaf Identifier is coming for different cases, we have to take a bit time to analyze the tree
-      // in order to know what we have to autocomplete exactly.
+      // As the leaf Identifier is coming for different cases, we have to take time to analyze the tree
+      // to know what we have to autocomplete exactly.
       // Here is some cases:
       // 1. metric_name / ignor --> we should autocomplete the BinOpModifier + metric/function/aggregation
       // 2. sum(http_requests_total{method="GET"} / o) --> BinOpModifier + metric/function/aggregation
@@ -307,36 +306,34 @@ export function analyzeCompletion(state: EditorState, node: SyntaxNode): Context
       //         VectorSelector(Identifier)
       //       )
       //
-      // So the first things to do is to get the `Parent` and to determinate if we are in this configuration.
-      // Otherwise we would just have to autocomplete the metric / function / aggregation.
+      // So the first thing to do is to get the `Parent` and to determinate if we are in this configuration.
+      // Otherwise, we would just have to autocomplete the metric / function / aggregation.
 
       const parent = node.parent?.parent;
       if (!parent) {
-        // this case can be possible if the topNode is not anymore PromQL but MetricName.
+        // This case can be possible if the topNode is not anymore PromQL but MetricName.
         // In this particular case, then we just want to autocomplete the metric
         result.push({ kind: ContextKind.MetricName, metricName: state.sliceDoc(node.from, node.to) });
         break;
       }
       // now we have to know if we have two Expr in the direct children of the `parent`
       const containExprTwice = containsChild(parent, 'Expr', 'Expr');
-      if (containExprTwice) {
-        if (parent.type.id === BinaryExpr && !containsAtLeastOneChild(parent, 0)) {
-          // We are likely in the case 1 or 5
-          result.push(
-            { kind: ContextKind.MetricName, metricName: state.sliceDoc(node.from, node.to) },
-            { kind: ContextKind.Function },
-            { kind: ContextKind.Aggregation },
-            { kind: ContextKind.BinOpModifier },
-            { kind: ContextKind.Number }
-          );
-          // in  case the BinaryExpr is a comparison, we should autocomplete the `bool` keyword. But only if it is not present.
-          // When the `bool` keyword is NOT present, then the expression looks like this:
-          // 			BinaryExpr( ..., Gtr , ... )
-          // When the `bool` keyword is present, then the expression looks like this:
-          //      BinaryExpr( ..., Gtr , BoolModifier(...), ... )
-          if (containsAtLeastOneChild(parent, Eql, Gte, Gtr, Lte, Lss, Neq) && !containsAtLeastOneChild(parent, BoolModifier)) {
-            result.push({ kind: ContextKind.Bool });
-          }
+      if (containExprTwice && parent.type.id === BinaryExpr && !containsAtLeastOneChild(parent, 0)) {
+        // We are likely in the case 1 or 5
+        result.push(
+          { kind: ContextKind.MetricName, metricName: state.sliceDoc(node.from, node.to) },
+          { kind: ContextKind.Function },
+          { kind: ContextKind.Aggregation },
+          { kind: ContextKind.BinOpModifier },
+          { kind: ContextKind.Number }
+        );
+        // In case the BinaryExpr is a comparison, we should autocomplete the `bool` keyword. But only if it is not present.
+        // When the `bool` keyword is NOT present, then the expression looks like this:
+        // 			BinaryExpr( ..., Gtr , ... )
+        // When the `bool` keyword is present, then the expression looks like this:
+        //      BinaryExpr( ..., Gtr , BoolModifier(...), ... )
+        if (containsAtLeastOneChild(parent, Eql, Gte, Gtr, Lte, Lss, Neq) && !containsAtLeastOneChild(parent, BoolModifier)) {
+          result.push({ kind: ContextKind.Bool });
         }
       } else {
         result.push(
@@ -413,24 +410,9 @@ export function analyzeCompletion(state: EditorState, node: SyntaxNode): Context
         });
       }
       break;
-    case NumberLiteral:
-      if (node.parent?.type.id === 0 && node.parent.parent?.type.id === SubqueryExpr) {
-        // Here we are likely in this situation:
-        //     `go[5d:4]`
-        // and we have the given tree:
-        // SubqueryExpr(
-        //   VectorSelector(Identifier),
-        //   Duration, Duration, ⚠(NumberLiteral)
-        // )
-        // So we should continue to autocomplete a duration
-        result.push({ kind: ContextKind.Duration });
-      } else {
-        result.push({ kind: ContextKind.Number });
-      }
-      break;
-    case Duration:
+    case NumberDurationLiteral:
     case OffsetExpr:
-      result.push({ kind: ContextKind.Duration });
+      result.push({ kind: ContextKind.Duration }, { kind: ContextKind.Number });
       break;
     case FunctionCallBody:
       // In this case we are in the given situation:
@@ -488,6 +470,8 @@ export class HybridComplete implements CompleteStrategy {
 
   promQL(context: CompletionContext): Promise<CompletionResult | null> | CompletionResult | null {
     const { state, pos } = context;
+    // In case you would like to print the syntax tree (for debugging purpose), you can do it like that:
+    // console.log(syntaxTree(state).toString())
     const tree = syntaxTree(state).resolve(pos, -1);
     const contexts = analyzeCompletion(state, tree);
     let asyncResult: Promise<Completion[]> = Promise.resolve([]);

--- a/web/ui/module/codemirror-promql/src/parser/path-finder.ts
+++ b/web/ui/module/codemirror-promql/src/parser/path-finder.ts
@@ -22,7 +22,6 @@ export function walkBackward(node: SyntaxNode | null, exit: number): SyntaxNode 
     }
     node = node.parent;
   }
-  return null;
 }
 
 export function containsAtLeastOneChild(node: SyntaxNode, ...child: (number | string)[]): boolean {

--- a/web/ui/module/codemirror-promql/src/parser/type.ts
+++ b/web/ui/module/codemirror-promql/src/parser/type.ts
@@ -17,7 +17,7 @@ import {
   BinaryExpr,
   FunctionCall,
   MatrixSelector,
-  NumberLiteral,
+  NumberDurationLiteral,
   OffsetExpr,
   ParenExpr,
   StepInvariantExpr,
@@ -42,7 +42,7 @@ export function getType(node: SyntaxNode | null): ValueType {
       return getType(node.firstChild);
     case StringLiteral:
       return ValueType.string;
-    case NumberLiteral:
+    case NumberDurationLiteral:
       return ValueType.scalar;
     case MatrixSelector:
       return ValueType.matrix;

--- a/web/ui/module/lezer-promql/src/promql.grammar
+++ b/web/ui/module/lezer-promql/src/promql.grammar
@@ -29,7 +29,7 @@ expr[@isGroup=Expr] {
   BinaryExpr |
   FunctionCall |
   MatrixSelector |
-  NumberLiteral |
+  NumberDurationLiteral |
   OffsetExpr |
   ParenExpr |
   StringLiteral |
@@ -192,16 +192,16 @@ ParenExpr {
 }
 
 OffsetExpr {
-  expr Offset Sub? Duration
+  expr Offset NumberDurationLiteral
 }
 
 MatrixSelector {
   // TODO: Can this not be more specific than "expr"?
-  expr "[" Duration "]"
+  expr "[" NumberDurationLiteral "]"
 }
 
 SubqueryExpr {
-  expr "[" Duration ":" ("" | Duration) "]"
+  expr "[" NumberDurationLiteral ":" ("" | NumberDurationLiteral) "]"
 }
 
 UnaryExpr {
@@ -235,14 +235,14 @@ LabelMatcher {
 }
 
 StepInvariantExpr {
-  expr At ( NumberLiteral | AtModifierPreprocessors "(" ")" )
+  expr At ( NumberDurationLiteral | AtModifierPreprocessors "(" ")" )
 }
 
 AtModifierPreprocessors {
   Start | End
 }
 
-NumberLiteral  {
+NumberDurationLiteral  {
  ("-"|"+")?~signed (number | inf | nan)
 }
 
@@ -254,7 +254,7 @@ NumberLiteral  {
 
   number {
       (std.digit+ ("." std.digit*)? | "." std.digit+) (("e" | "E") ("+" | "-")? std.digit+)? |
-      "0x" (std.digit | $[a-fA-F])+
+      "0x" (std.digit | $[a-fA-F])+ | duration
   }
   StringLiteral { // TODO: This is for JS, make this work for PromQL.
     '"' (![\\\n"] | "\\" _)* '"'? |
@@ -262,7 +262,7 @@ NumberLiteral  {
     "`" ![`]* "`"
   }
 
-  Duration {
+  duration {
     // Each line below is just the same regex repeated over and over, but each time with one of the units made non-optional,
     // to ensure that at least one <number>+<unit> pair is provided and an empty string is not recognized as a valid duration.
     ( ( std.digit+ "y" ) ( std.digit+ "w" )? ( std.digit+ "d" )? ( std.digit+ "h" )? ( std.digit+ "m" )? ( std.digit+ "s" )? ( std.digit+ "ms" )? ) |

--- a/web/ui/module/lezer-promql/test/expression.txt
+++ b/web/ui/module/lezer-promql/test/expression.txt
@@ -4,7 +4,7 @@
 
 ==>
 
-PromQL(NumberLiteral)
+PromQL(NumberDurationLiteral)
 
 # Double-quoted string literal
 
@@ -46,7 +46,7 @@ PromQL(StringLiteral)
 
 ==>
 
-PromQL(BinaryExpr(NumberLiteral, Add, NumberLiteral))
+PromQL(BinaryExpr(NumberDurationLiteral, Add, NumberDurationLiteral))
 
 # Complex expression
 
@@ -73,7 +73,7 @@ PromQL(
                             VectorSelector(
                                 Identifier
                             ),
-                          Duration
+                          NumberDurationLiteral
                         )
                   )
                 )
@@ -103,7 +103,7 @@ PromQL(
                             VectorSelector(
                                 Identifier
                             ),
-                          Duration
+                          NumberDurationLiteral
                       )
                   )
               )
@@ -192,21 +192,21 @@ PromQL(
   )
 )
 
-# Duration units
+# NumberDurationLiteral units
 
 foo[1y2w3d4h5m6s7ms]
 
 ==>
 
-PromQL(MatrixSelector(VectorSelector(Identifier),Duration))
+PromQL(MatrixSelector(VectorSelector(Identifier),NumberDurationLiteral))
 
-# Incorrectly ordered duration units
+# Incorrectly ordered NumberDurationLiteral units
 
 foo[1m2h]
 
 ==>
 
-PromQL(SubqueryExpr(VectorSelector(Identifier),Duration,⚠,Duration))
+PromQL(MatrixSelector(VectorSelector(Identifier),NumberDurationLiteral,⚠))
 
 # Using a function name as a metric name
 
@@ -263,7 +263,7 @@ PromQL(
         ),
       Gtr,
       BoolModifier(Bool),
-      NumberLiteral
+      NumberDurationLiteral
     )
 )
 
@@ -309,7 +309,7 @@ PromQL(
                 VectorSelector(
                     Identifier
                 ),
-              Duration
+              NumberDurationLiteral
             )
       )
     )
@@ -341,8 +341,8 @@ PromQL(
       FunctionIdentifier(Clamp),
       FunctionCallBody(
         VectorSelector(Identifier),
-        NumberLiteral,
-        NumberLiteral
+        NumberDurationLiteral,
+        NumberDurationLiteral
       )
     )
 )
@@ -402,7 +402,7 @@ PromQL(
             Identifier
         ),
       At,
-      NumberLiteral
+      NumberDurationLiteral
   )
 )
 
@@ -435,7 +435,7 @@ PromQL(
           FunctionCallBody(
                 MatrixSelector(
                   VectorSelector(Identifier),
-                  Duration
+                  NumberDurationLiteral
                 )
           )
         ),
@@ -443,14 +443,14 @@ PromQL(
         AggregateExpr(
           AggregateOp(Topk),
           FunctionCallBody(
-            NumberLiteral,
+            NumberDurationLiteral,
             FunctionCall(
               FunctionIdentifier(Rate),
               FunctionCallBody(
                 StepInvariantExpr(
-                  MatrixSelector(VectorSelector(Identifier), Duration),
+                  MatrixSelector(VectorSelector(Identifier), NumberDurationLiteral),
                   At,
-                  NumberLiteral
+                  NumberDurationLiteral
                 )
               )
             )
@@ -470,7 +470,7 @@ PromQL(
             Identifier
         ),
       At,
-      NumberLiteral
+      NumberDurationLiteral
     )
 )
 
@@ -485,7 +485,7 @@ PromQL(
             Identifier
         ),
       At,
-      NumberLiteral
+      NumberDurationLiteral
     )
 )
 
@@ -508,98 +508,98 @@ PromQL(VectorSelector(Identifier))
 NaN
 
 ==>
-PromQL(NumberLiteral)
+PromQL(NumberDurationLiteral)
 
 # Lower-cased NaN.
 
 nan
 
 ==>
-PromQL(NumberLiteral)
+PromQL(NumberDurationLiteral)
 
 # Inf.
 
 Inf
 
 ==>
-PromQL(NumberLiteral)
+PromQL(NumberDurationLiteral)
 
 # Negative Inf.
 
 -Inf
 
 ==>
-PromQL(NumberLiteral)
+PromQL(NumberDurationLiteral)
 
 # Positive Inf.
 
 +Inf
 
 ==>
-PromQL(NumberLiteral)
+PromQL(NumberDurationLiteral)
 
 # Lower-cased Inf.
 
 inf
 
 ==>
-PromQL(NumberLiteral)
+PromQL(NumberDurationLiteral)
 
 # Upper-cased Inf.
 
 INF
 
 ==>
-PromQL(NumberLiteral)
+PromQL(NumberDurationLiteral)
 
 # Negative number literal.
 
 -42
 
 ==>
-PromQL(NumberLiteral)
+PromQL(NumberDurationLiteral)
 
 # Explicitly positive number literal.
 
 +42
 
 ==>
-PromQL(NumberLiteral)
+PromQL(NumberDurationLiteral)
 
 # Trying to illegally use NaN as a metric name.
 
 NaN{foo="bar"}
 
 ==>
-PromQL(BinaryExpr(NumberLiteral,⚠,VectorSelector(LabelMatchers(LabelMatcher(LabelName,MatchOp(EqlSingle),StringLiteral)))))
+PromQL(BinaryExpr(NumberDurationLiteral,⚠,VectorSelector(LabelMatchers(LabelMatcher(LabelName,MatchOp(EqlSingle),StringLiteral)))))
 
 # Trying to illegally use Inf as a metric name.
 
 Inf{foo="bar"}
 
 ==>
-PromQL(BinaryExpr(NumberLiteral,⚠,VectorSelector(LabelMatchers(LabelMatcher(LabelName,MatchOp(EqlSingle),StringLiteral)))))
+PromQL(BinaryExpr(NumberDurationLiteral,⚠,VectorSelector(LabelMatchers(LabelMatcher(LabelName,MatchOp(EqlSingle),StringLiteral)))))
 
 # Negative offset
 
 foo offset -5d
 
 ==>
-PromQL(OffsetExpr(VectorSelector(Identifier), Offset, Sub, Duration))
+PromQL(OffsetExpr(VectorSelector(Identifier), Offset, NumberDurationLiteral))
 
 # Negative offset with space
 
 foo offset - 5d
 
 ==>
-PromQL(OffsetExpr(VectorSelector(Identifier), Offset, Sub, Duration))
+PromQL(OffsetExpr(VectorSelector(Identifier), Offset, NumberDurationLiteral))
 
 # Positive offset
 
 foo offset 5d
 
 ==>
-PromQL(OffsetExpr(VectorSelector(Identifier), Offset, Duration))
+PromQL(OffsetExpr(VectorSelector(Identifier), Offset, NumberDurationLiteral))
 
 # Parsing only metric names with alternative @top { "top": "MetricName" }
 
@@ -613,4 +613,4 @@ MetricName(Identifier)
 1 + foo atan2 bar
 
 ==>
-PromQL(BinaryExpr(NumberLiteral,Add,BinaryExpr(VectorSelector(Identifier),Atan2,VectorSelector(Identifier))))
+PromQL(BinaryExpr(NumberDurationLiteral,Add,BinaryExpr(VectorSelector(Identifier),Atan2,VectorSelector(Identifier))))


### PR DESCRIPTION
Hi @darshanime,

Here the PR that modifies the frontend to support what you did in the backend.
That should complete your PR in Prometheus and we should be able to merge it once the conflict are resolved :).

@juliusv would you like to review it here ? Or do you prefer to review it in the PR opened in Prometheus ? (https://github.com/prometheus/prometheus/pull/9138) 